### PR TITLE
feat(docs): updated the local setup instructions and some default values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
-DB_NAME=qapp
+DB_NAME=elg_search
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres
-DB_PASS=password
+DB_PASS=postgres
 BASE_URL=http://localhost:8080
+ELG_GLOSSARY_AUTH=
 VUE_APP_API_URL="http://localhost:3001"

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -1,18 +1,30 @@
+# Local Development Setup
 
-**Prerequisites**
-- install Node.js from https://nodejs.org
-- install postgresql from https://www.postgresql.org/
+## Prerequisites
 
-** Steps to run application locally**
-- git clone this repo
-- run "npm install" in the base directory to install dependencies from NPM
-- run "npm start" to concurrently run the node express server and vue-cli server
-- If you prefer to run express and vue-cli in separate terminals, run "npm run server" and "npm run client"
+- Install Node.js from https://nodejs.org
+- Install PostgreSQL from https://www.postgresql.org/
+
+## Steps to Run Locally
+
+- `git clone` this repo.
+- In the root directory, copy `.env.example` to `.env.local`, modifying the `DB_USER` & `DB_PASS` variables as needed for your PostgreSQL superuser.
+- Run "npm run setup" in the base directory to install dependencies from NPM and create/seed the database.
+- Run "npm start" to concurrently run the node express server and vue-cli server.
+  - If you prefer to run express and vue-cli in separate terminals, run "npm run server" and "npm run client".
 - If you're planning to submit code updates, see [contribute.md](contribute.md).
 - For future repo updates, run npm ci from the base directory to ensure dependencies are up to date.
 
-** Commands to fix lint issues **
+## Commands to Fix Lint Issues
+
 In the base directory, run:
-- npm run lint -- --fix
-or 
-- npx eslint [path] --fix (for a specific file)
+
+```
+npm run lint -- --fix
+```
+
+or, for a specific file:
+
+```
+npx eslint [path] --fix
+```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "migrate": "sequelize db:migrate:undo:all && sequelize db:migrate",
     "prod": "node server/src/server.js",
     "seed": "sequelize db:seed:all",
-    "server": "nodemon --ignore client/* --ignore server/src/s3/glossary.json --inspect server/src/server.js",
+    "server": "nodemon --ignore 'client/*' --ignore server/src/s3/glossary.json --inspect server/src/server.js",
+    "setup": "npm ci && npx sequelize db:create && npm run migrate && npm run seed",
     "start": "cross-env NODE_ENV=local concurrently --kill-others -n server,client \"npm run server\" \"npm run client\"",
     "test": "vue-cli-service test:unit"
   },

--- a/server/src/config/config.js
+++ b/server/src/config/config.js
@@ -1,4 +1,4 @@
-const logger = require("../../utilities/logger.js");
+const logger = require('../../utilities/logger.js');
 const log = logger.logger;
 
 let isLocal = false;
@@ -6,51 +6,51 @@ let isDevelopment = false;
 let isStaging = false;
 
 let db = {
-  database: "elg_search",
-  user: "postgres",
-  password: "postgres",
+  database: process.env.DB_NAME ?? 'elg_search',
+  user: process.env.DB_USER ?? 'postgres',
+  password: process.env.DB_PASS ?? 'postgres',
   options: {
-    dialect: "postgres",
-    host: "localhost",
-    port: "5432"
-  }
+    dialect: 'postgres',
+    host: process.env.DB_HOST ?? 'localhost',
+    port: process.env.DB_PORT ?? '5432',
+  },
 };
 
 if (process.env.NODE_ENV) {
-  isLocal = "local" === process.env.NODE_ENV.toLowerCase();
-  isDevelopment = "development" === process.env.NODE_ENV.toLowerCase();
-  isStaging = "staging" === process.env.NODE_ENV.toLowerCase();
+  isLocal = process.env.NODE_ENV.toLowerCase() === 'local';
+  isDevelopment = process.env.NODE_ENV.toLowerCase() === 'development';
+  isStaging = process.env.NODE_ENV.toLowerCase() === 'staging';
 }
 
 if (isLocal) {
-  log.info("Since local, using a localhost Postgres database.");
+  log.info('Since local, using a localhost Postgres database.');
 } else {
   if (process.env.VCAP_SERVICES) {
-    log.info("Using VCAP_SERVICES Information to connect to Postgres.");
+    log.info('Using VCAP_SERVICES Information to connect to Postgres.');
     vcap_services = JSON.parse(process.env.VCAP_SERVICES);
     db = {
-      database: "postgres",
-      user: vcap_services["aws-rds"][0].credentials.username,
-      password: vcap_services["aws-rds"][0].credentials.password,
+      database: 'postgres',
+      user: vcap_services['aws-rds'][0].credentials.username,
+      password: vcap_services['aws-rds'][0].credentials.password,
       options: {
-        dialect: "postgres",
-        host: vcap_services["aws-rds"][0].credentials.host,
-        port: vcap_services["aws-rds"][0].credentials.port
-      }
+        dialect: 'postgres',
+        host: vcap_services['aws-rds'][0].credentials.host,
+        port: vcap_services['aws-rds'][0].credentials.port,
+      },
     };
   } else {
-    log.info("VCAP_SERVICES Information not found. Attempting connection to localhost...");
+    log.info('VCAP_SERVICES Information not found. Attempting connection to localhost...');
   }
 }
 
 module.exports = {
   port: process.env.PORT || 3001,
-  db: db,
+  db,
   authentication: {
-    jwtSecret: process.env.JWT_SECRET || "secret"
+    jwtSecret: process.env.JWT_SECRET || 'secret',
   },
-  service: process.env.SERVICE_PROVIDER || "Gmail",
-  email: process.env.EMAIL || "elg@gmail.com",
-  emailPassword: process.env.EMAIL_PASSWORD || "password",
-  baseUrl: process.env.BASE_URL || "http://localhost:8080"
+  service: process.env.SERVICE_PROVIDER || 'Gmail',
+  email: process.env.EMAIL || 'elg@gmail.com',
+  emailPassword: process.env.EMAIL_PASSWORD || 'password',
+  baseUrl: process.env.BASE_URL || 'http://localhost:8080',
 };


### PR DESCRIPTION
Many of the changes are just due to my editor auto-formatting per the project's Prettier configuration file. The other changes, highlighted below and updated in the local setup instructions, were necessary to get the application to run locally.

## Main Changes:
- The `.env.example` file did not include the `ELG_GLOSSARY_AUTH` variable, and the server does not start without it. I added it to `.env.example`, but looking more closely, it's only needed locally for syncing (the glossary file is already present). I updated the server code to still show the warning if the variable is missing, but to continue to run.
- For the database configuration, the environment variables were not being used at all locally. I updated the server `config.js` file to pull from the environment variables instead of using hard-coded values.
- The setup instructions made no mention about creating and populating the database. I added a `setup` script that installs dependencies, then creates the database and tables and seeds the data.