### PR TITLE
fix(docs): fixed minor error in instructions

### DIFF
--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -8,7 +8,7 @@
 ## Steps to Run Locally
 
 - `git clone` this repo.
-- In the root directory, copy `.env.example` to `.env.local`, modifying the `DB_USER` & `DB_PASS` variables as needed for your PostgreSQL superuser.
+- In the root directory, copy `.env.example` to `.env`, modifying the `DB_USER` & `DB_PASS` variables as needed for your PostgreSQL superuser.
 - Run "npm run setup" in the base directory to install dependencies from NPM and create/seed the database.
 - Run "npm start" to concurrently run the node express server and vue-cli server.
   - If you prefer to run express and vue-cli in separate terminals, run "npm run server" and "npm run client".


### PR DESCRIPTION
## Main Changes:

This is a very minor change, but in the previous PR (#124), I mistakenly specified that `.env.example` should be copied to `.env.local` in the instructions. However, since that filename isn't specified in the NPM script, the `dotenv` default is actually `.env`.