### PR TITLE
Fixed trailing whitespace issue and improper property access

### DIFF
--- a/app/server/src/controllers/limitation.js
+++ b/app/server/src/controllers/limitation.js
@@ -693,7 +693,9 @@ function getTechnologyCodeWhereClause(techCodes) {
     let technologyCodeOrList = [];
     techCodes.forEach((techCode) => {
       technologyCodeOrList.push(
-        "lower('" + techCode + "') IN (SELECT codes FROM regexp_split_to_table(lower(treatment_codes), '; ') AS codes)"
+        "lower('" +
+          techCode +
+          "') IN (SELECT codes FROM regexp_split_to_table(lower(trim(treatment_codes)), '; ') AS codes)"
       );
     });
 

--- a/app/server/src/controllers/treatmentTechnology.js
+++ b/app/server/src/controllers/treatmentTechnology.js
@@ -696,7 +696,7 @@ module.exports = {
                                 {
                                   label: 'Treatment Trains',
                                   value: (params.treatmentIds.length > 0
-                                    ? [...new Set(limitations.map((lim) => lim.treatmentNames))]
+                                    ? [...new Set(limitations.rows.map((lim) => lim.treatmentNames))]
                                     : []
                                   ).join(', '),
                                 },


### PR DESCRIPTION
## Main Changes:

- Added a call to the `trim()` SQL function before splitting `treatment_codes` into a table for comparison.
- Updated the property being mapped over in one case (the `findAndCountAll` returns an object with two properties, `count` and `rows`, rather than just an array of results).